### PR TITLE
Use the correct EOL string for the OS we're on.

### DIFF
--- a/src/ai/BotLoader.js
+++ b/src/ai/BotLoader.js
@@ -1,3 +1,5 @@
+var os = require('os');
+
 // Project imports
 var BotPlayer = require('./BotPlayer');
 var FakeSocket = require('./FakeSocket');
@@ -39,7 +41,7 @@ BotLoader.prototype.loadNames = function() {
     var fs = require("fs"); // Import the util library
 	
     // Read and parse the names
-    this.randomNames = fs.readFileSync("./botnames.txt", "utf8").split('\r\n');
+    this.randomNames = fs.readFileSync("./botnames.txt", "utf8").split(os.EOL);
 };
 
 


### PR DESCRIPTION
I was seeing a single bot with a very long name, and the rest were called 'bot2', etc.

The botnames file doesn't have \r characters for me, so the split wasn't working.